### PR TITLE
add dropout and CIFAR100 example notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## ResMLP - Pytorch
 
+<a href="https://colab.research.google.com/drive/1rCN0esWLLTm8yEQmz3uRSYcqGiGKfGMP?usp=sharing" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>
+
 Implementation of <a href="https://arxiv.org/abs/2105.03404">ResMLP</a>, an all MLP solution to image classification out of Facebook AI, in Pytorch
 
 ## Install
@@ -21,6 +23,7 @@ model = ResMLP(
     patch_size = 16,
     dim = 512,
     depth = 12,
+    dropout_rate=0.5,
     num_classes = 1000
 )
 
@@ -39,6 +42,7 @@ model = ResMLP(
     patch_size = 16,
     dim = 512,
     depth = 12,
+    dropout_rate=0.5,
     num_classes = 1000
 )
 
@@ -50,7 +54,7 @@ pred = model(img) # (1, 1000)
 
 ```bibtex
 @misc{touvron2021resmlp,
-    title   = {ResMLP: Feedforward networks for image classification with data-efficient training}, 
+    title   = {ResMLP: Feedforward networks for image classification with data-efficient training},
     author  = {Hugo Touvron and Piotr Bojanowski and Mathilde Caron and Matthieu Cord and Alaaeldin El-Nouby and Edouard Grave and Armand Joulin and Gabriel Synnaeve and Jakob Verbeek and Hervé Jégou},
     year    = {2021},
     eprint  = {2105.03404},

--- a/res_mlp_pytorch/res_mlp_pytorch.py
+++ b/res_mlp_pytorch/res_mlp_pytorch.py
@@ -36,7 +36,7 @@ class PreAffinePostLayerScale(nn.Module): # https://arxiv.org/abs/2103.17239
     def forward(self, x):
         return self.fn(self.affine(x)) * self.scale + x
 
-def ResMLP(*, image_size, patch_size, dim, depth, num_classes, expansion_factor = 4):
+def ResMLP(*, image_size, patch_size, dim, depth, num_classes, expansion_factor = 4, dropout_rate=0.0):
     image_height, image_width = pair(image_size)
     assert (image_height % patch_size) == 0 and (image_width % patch_size) == 0, 'image height and width must be divisible by patch size'
     num_patches = (image_height // patch_size) * (image_width // patch_size)
@@ -50,7 +50,9 @@ def ResMLP(*, image_size, patch_size, dim, depth, num_classes, expansion_factor 
             wrapper(i, nn.Sequential(
                 nn.Linear(dim, dim * expansion_factor),
                 nn.GELU(),
-                nn.Linear(dim * expansion_factor, dim)
+                nn.Dropout(p=dropout_rate),
+                nn.Linear(dim * expansion_factor, dim),
+                nn.Dropout(p=dropout_rate),
             ))
         ) for i in range(depth)],
         Affine(dim),


### PR DESCRIPTION
- According to [ResMLP paper](https://arxiv.org/pdf/2105.03404.pdf), it appears that dropout layer has been implemented in Machine translation when using ResMLP.
```
We use Adagrad with learning rate 0.2, 32k steps of linear warmup, label smoothing 0.1, dropout rate 0.15 for En-De and 0.1 for En-Fr.
```
- Since MLP literatures often mention that MLP is susceptible to overfitting, which is one of the reason why weight decay is so high, implementing dropout will be reasonable choice of regularization.

<a href="https://colab.research.google.com/drive/1rCN0esWLLTm8yEQmz3uRSYcqGiGKfGMP?usp=sharing" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a> | [🔗 Wandb Log](https://wandb.ai/snoop2head/CIFAR-MLP?workspace=user-snoop2head)
- Above is my simple experimentation on CIFAR100 dataset, with three different dropout rates: [0.0, 0.25, 0.5]. 
- Higher dropout yielded better test metrics(loss, acc1 and acc5).